### PR TITLE
Fixed not working header buttons (cog)

### DIFF
--- a/webd/host_manager.php
+++ b/webd/host_manager.php
@@ -49,10 +49,9 @@ require_once __DIR__ .'/parts/head.php';
                     <div class="content-header-buttons">
                         <div class="content-header-button">
                             <!-- header button area, example for add new machine button. -->
-                            <button class="btn btn-sm"><i class="fa fa-plus"></i><?php echo _('add new machine'); ?></button>
+                            <button class="btn btn-sm" data-modal="open" data-modal-target="machine_list-setting"><i class="fa fa-plus"></i><?php echo _('add new machine'); ?></button>
                         </div>
                          <!-- setting button, open setting modal. this is optional button. -->
-                        <button class="content-header-setting"  data-modal="open" data-modal-target="machine_list-setting"><i class="fa fa-cog"></i></button>
                     </div>
                 </div>
 

--- a/webd/logger.php
+++ b/webd/logger.php
@@ -49,7 +49,6 @@ require_once __DIR__ .'/parts/head.php';
                 <!-- page general setting button and useful buttons area -->
                 <div class="content-header-buttons">
                     <!-- setting button, open setting modal. this is optional button. -->
-                    <button class="content-header-setting" data-modal="open" data-modal-target="machine_list-setting"><i class="fa fa-cog"></i></button>
                 </div>
             </div>
             <form action="includes/manager_host_checkbox.php" method="post">

--- a/webd/target_list.php
+++ b/webd/target_list.php
@@ -62,11 +62,10 @@ $dbh = $dba->Connect();
                 <div class="content-header-buttons">
                     <div class="content-header-button">
                         <!-- header button area, example for add new machine button. -->
-                        <button class="btn btn-sm"><i class="fa fa-plus"></i>新規マシン追加</button>
+                        <button class="btn btn-sm" data-modal="open"
+                            data-modal-target="target_host_list-setting"><i class="fa fa-plus"></i>新規マシン追加</button>
                     </div>
                     <!-- setting button, open setting modal. this is optional button. -->
-                    <button class="content-header-setting" data-modal="open"
-                            data-modal-target="target_host_list-setting"><i class="fa fa-cog"></i></button>
                 </div>
             </div>
             <form action="includes/target_host_checkbox.php" method="post">


### PR DESCRIPTION
host_manager.phpとtarget_list.phpの歯車ボタンに設定されていた設定モーダルを開く動作を新規マシン追加ボタンに移動しました。
移動に伴って上記２ファイルとlogger.phpの現在使用していない歯車の設定ボタンを削除しました。